### PR TITLE
Bump version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(name):
 
 setup(
     name='django-facebook-auth',
-    version='3.6.2',
+    version='3.6.3',
     description="Authorisation app for Facebook API.",
     long_description=read("README.rst"),
     maintainer="Tomasz Wysocki",


### PR DESCRIPTION
Version 3.6.2 was released on pypi without https://github.com/pozytywnie/django-facebook-auth/pull/28
