### PR TITLE
Use application access token to get user by id.

### DIFF
--- a/facebook_auth/backends.py
+++ b/facebook_auth/backends.py
@@ -70,8 +70,10 @@ class UserFactory(object):
         return self.fallback_expiration_date
 
     def get_user_by_id(self, uid):
-        graph_api = graph_api.get_graph(timeout=FACEBOOK_TIMEOUT)
-        profile = utils.get_from_graph_api(graph_api, uid)
+        api = utils.get_application_graph(
+            version=settings.FACEBOOK_API_VERSION
+        )
+        profile = utils.get_from_graph_api(api, uid)
         return self._product_user(None, profile)
 
     def create_profile_object(self, profile, user):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(name):
 
 setup(
     name='django-facebook-auth',
-    version='3.7.1',
+    version='3.7.2',
     description="Authorisation app for Facebook API.",
     long_description=read("README.rst"),
     maintainer="Tomasz Wysocki",
@@ -17,7 +17,7 @@ setup(
     install_requires=(
         'celery',
         'Django<1.8',
-        'facepy>=1.0.3',
+        'facepy-pozytywnie==1.0.5',
     ),
 
     packages=[


### PR DESCRIPTION
In v1.0, there were API endpoints that didn't require an access token to call.
In v2.0, all calls to endpoints now require an access token, except for calls to get an object's picture.
