### PR TITLE
Throw custom exception instead of ValueError.

### DIFF
--- a/facebook_auth/models.py
+++ b/facebook_auth/models.py
@@ -95,6 +95,10 @@ class UserToken(models.Model):
         verbose_name_plural = 'User tokens'
 
 
+class TokenDebugException(Exception):
+    pass
+
+
 class UserTokenManager(object):
     @staticmethod
     def insert_token(provider_user_id, token, expiration_date=None):
@@ -182,8 +186,8 @@ class FacebookTokenManager(object):
             self._update_scope(data)
             return self.get_token_info(data)
         else:
-            raise ValueError('Invalid Facebook response.',
-                             {'errors': parsed_response.errors})
+            raise TokenDebugException('Invalid Facebook response.',
+                                      {'errors': parsed_response.errors})
 
     def _update_scope(self, data):
         if 'scopes' in data:
@@ -201,7 +205,7 @@ def validate_token(access_token):
     manager = FacebookTokenManager()
     try:
         manager.debug_token(access_token)
-    except ValueError:
+    except TokenDebugException:
         logger.info('Invalid access token')
         token_manager = UserTokenManager()
         token_manager.invalidate_access_token(access_token)
@@ -242,7 +246,7 @@ def debug_all_tokens_for_user(user_id):
     for token in user_tokens:
         try:
             data = manager.debug_token(token)
-        except ValueError:
+        except TokenDebugException:
             logger.info('Invalid access token')
             token_manager.invalidate_access_token(token)
         else:

--- a/facebook_auth/tests.py
+++ b/facebook_auth/tests.py
@@ -359,7 +359,7 @@ class TestDebugAllTokensForUser(test.TestCase):
     @mock.patch.object(models, 'FacebookTokenManager')
     def test_negative_scenario(self, FacebookTokenManager):
         manager = FacebookTokenManager.return_value
-        manager.debug_token.side_effect = ValueError
+        manager.debug_token.side_effect = models.TokenDebugException
         token_manager = models.UserTokenManager()
         token_manager.insert_token('123', 'token1212', "2014-02-02")
         models.debug_all_tokens_for_user('123')


### PR DESCRIPTION
There was a case in the past that something throwed ValueError and it was swallowed by excepting ValueError from debug_token.