### PR TITLE
Log cases of username mismatch for Facebook users.

### DIFF
--- a/facebook_auth/backends.py
+++ b/facebook_auth/backends.py
@@ -39,7 +39,16 @@ class UserFactory(object):
         user_id = int(profile['id'])
         username = self.__create_username(profile)
         user, created = models.FacebookUser.objects.get_or_create(
-                user_id=user_id, username=username)
+            user_id=user_id, defaults={'username': username})
+
+        if user.username != username:
+            logger.warning('FacebookUser username mismatch', extra={
+                'old_username': user.username,
+                'new_username': username,
+                'user_django_id': user.id,
+                'user_facebook_id': user_id,
+                'user_email': user.email
+            })
         if created:
             user.set_unusable_password()
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(name):
 
 setup(
     name='django-facebook-auth',
-    version='3.7.5',
+    version='3.7.6',
     description="Authorisation app for Facebook API.",
     long_description=read("README.rst"),
     maintainer="Tomasz Wysocki",


### PR DESCRIPTION
Both fields are unique, but not together. If username is different then query will fail with IntegrityError.